### PR TITLE
Add GitHub Actions workflow for atuomatic releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: New Features & Changes
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit_test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install ffmpeg
+        uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          version: 7.1
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --all-features
+        env:
+          RUST_BACKTRACE: "full"
+
+  build:
+    name: Build for ${{ matrix.os }}
+    needs: unit_test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: audio2tonie-linux
+          - os: windows-latest
+            artifact_name: audio2tonie-windows
+          - os: macos-latest
+            artifact_name: audio2tonie-macos
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install ffmpeg
+        uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          version: 7.1
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Prepare artifacts
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            mv target/release/audio2tonie.exe audio2tonie.exe
+            zip -j ${{ matrix.artifact_name }}.zip audio2tonie.exe
+          else
+            mv target/release/audio2tonie audio2tonie
+            zip -j ${{ matrix.artifact_name }}.zip audio2tonie
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}.zip
+
+  test:
+    name: Test Linux Binary
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Install ffmpeg
+        uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          version: 7.1
+
+      - name: Test Linux binary
+        shell: bash
+        run: |
+          unzip artifacts/audio2tonie-linux/audio2tonie-linux.zip
+          chmod +x audio2tonie
+          ./audio2tonie --help
+
+  release:
+    name: Create Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            artifacts/audio2tonie-linux/audio2tonie-linux.zip
+            artifacts/audio2tonie-windows/audio2tonie-windows.zip
+            artifacts/audio2tonie-macos/audio2tonie-macos.zip
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ This project is a command-line interface (CLI) application that converts audio f
 
 ## Installation
 
+### Option 1: Download Pre-built Binary
+
+Download the latest release for your platform from the [GitHub releases page](https://github.com/hotzenklotz/audio2tonie/releases):
+
+- Windows: `audio2tonie-windows.zip`
+- Linux: `audio2tonie-linux.zip`
+- macOS: `audio2tonie-macos.zip`
+
+Extract the zip file and make the binary executable (on Linux/macOS):
+```bash
+chmod +x audio2tonie
+```
+
+### Option 2: Build from Source
+
+If you prefer to build from source:
+
 ```bash
 cargo install --path .
 ```


### PR DESCRIPTION
Added GitHub Actions workflow for atuomatic releases that will build binaries for Window, Linux and MacOS.

Builds will be added as GitHub releases and can be downloaded there. 